### PR TITLE
method and tests to add an instance to an environment

### DIFF
--- a/engineyard-cloud-client.gemspec
+++ b/engineyard-cloud-client.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('ey_resolver', '~>0.2.1')
   s.add_development_dependency('rabl')
   s.add_development_dependency('oj')
+  s.add_development_dependency('pry')
 end

--- a/lib/engineyard-cloud-client/errors.rb
+++ b/lib/engineyard-cloud-client/errors.rb
@@ -3,9 +3,10 @@ module EY
     class Error < RuntimeError
     end
 
-    class RequestFailed      < Error; end
-    class InvalidCredentials < RequestFailed; end
-    class ResourceNotFound   < RequestFailed; end
+    class RequestFailed       < Error; end
+    class InvalidCredentials  < RequestFailed; end
+    class ResourceNotFound    < RequestFailed; end
+    class InvalidInstanceRole < Error; end
 
     class BadEndpointError < Error
       def initialize(endpoint)

--- a/lib/engineyard-cloud-client/models/environment.rb
+++ b/lib/engineyard-cloud-client/models/environment.rb
@@ -169,6 +169,36 @@ module EY
         name.gsub(/^#{Regexp.quote(app.name)}_/, '')
       end
 
+      # Throws a POST request at the API to /add_instances and adds one instance
+      # to this environment.
+      #
+      # Usage example:
+      #
+      # api = EY::CloudClient.new(token: 'your token here')
+      # e = (api.environments.select { |x| x.name == 'your_env_name'}).first
+      # e.add_instance(role: "app")
+      #
+      # Or -
+      #
+      # e.add_instance(role: "util", name: "foo")
+      #
+      # Note that the role for an instance MUST be either "app" or "util".
+      # No other value is acceptable. The "name" parameter can be anything,
+      # but it only applies to utility instances.
+      def add_instance(opts)
+        unless opts[:role] && ["app", "util"].include?(opts[:role])
+          # Fail immediately because we don't have valid arguments.
+          raise InvalidInstanceRole, "Instance role must be one of: app, util"
+        end
+
+        # We know opts[:role] is right, name can be passed straight to the API.
+        # Return the response body for error output, logging, etc.
+        return api.post("/environments/#{id}/add_instances", request: {
+          "role" => opts[:role],
+          "name" => opts[:name]
+        })
+      end
+
       protected
 
       def set_account(account_attrs)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require 'rspec'
 require 'tmpdir'
 require 'yaml'
 require 'pp'
+require 'pry'
 support = Dir[File.join(EY_ROOT,'/spec/support/*.rb')]
 support.each{|helper| require helper }
 


### PR DESCRIPTION
Despite the name, this PR adds functionality to the project to add instances of _either_ app or util to a given environment. (I started thinking, "I'll focus on the simplest use case - app - and go from there", but it turned out being a no-brainer for utils too).

Usage example:

```
api = EY::CloudClient.new(token: 'token')
e = (api.environments.select { |x| x.name == 'something' }).first
e.add_instance(role: 'util', name: 'elasticsearch')
e.add_instance(role 'app')
```

Returns the API response body (JSON).

Specs are included and all 77 examples pass.

Added the "pry" development dependency to make digging into things during spec execution easier.
