### PR TITLE
Time.parse is not available in real-world use

### DIFF
--- a/lib/engineyard-cloud-client/models/deployment.rb
+++ b/lib/engineyard-cloud-client/models/deployment.rb
@@ -1,6 +1,7 @@
 require 'engineyard-cloud-client/models/api_struct'
 require 'engineyard-cloud-client/errors'
 require 'stringio'
+require 'date'
 
 module EY
   class CloudClient
@@ -53,7 +54,7 @@ module EY
 
       def created_at=(cat)
         if String === cat
-          super Time.parse(cat)
+          super DateTime.parse(cat).to_time
         else
           super
         end
@@ -61,7 +62,7 @@ module EY
 
       def finished_at=(fat)
         if String === fat
-          super Time.parse(fat)
+          super DateTime.parse(fat).to_time
         else
           super
         end


### PR DESCRIPTION
see bottom of https://magnum.travis-ci.com/engineyard/ensemble/builds/1021850

```
/home/travis/.rvm/gems/ruby-1.9.3-p448/gems/engineyard-cloud-client-1.0.12/lib/engineyard-cloud-client/models/deployment.rb:56:in `created_at=': undefined method `parse' for Time:Class (NoMethodError)
```

Is it ok to release a new version with this change?
