### PR TITLE
Force instance addition with util to require a name, specify name when removing instances

### DIFF
--- a/lib/engineyard-cloud-client/errors.rb
+++ b/lib/engineyard-cloud-client/errors.rb
@@ -9,6 +9,7 @@ module EY
     class InvalidInstanceRole    < Error; end
     class InstanceNotProvisioned < Error; end
     class MultipleMatchesError   < RequestFailed; end
+    class InvalidInstanceName    < Error; end
 
     class BadEndpointError < Error
       def initialize(endpoint)


### PR DESCRIPTION
This change forces you to specify a name when adding a util instance so that you don't accidentally add something that's not valid, and it passes the name of the instance, be it util or app, when doing a removal request.
