### PR TITLE
Switch to rest-client instead of rest_client (subtle...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 engineyard-cloud-client contains a Ruby api library to the Engine Yard Cloud API. Extracted from the [engineyard gem](https://github.com/engineyard/engineyard).
 
+[![Build Status](https://travis-ci.org/engineyard/engineyard-cloud-client.svg?branch=master)](https://travis-ci.org/rest-client/rest-client)
+
 ## Version 2.0.x
 
 As of the 2.0 version series, we will only be supporting ruby versions 1.9.3 and

--- a/engineyard-cloud-client.gemspec
+++ b/engineyard-cloud-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('rest_client', '~>1.8')
+  s.add_dependency('rest-client', '~>1.7')
   s.add_dependency('multi_json', '~>1.6')
 
   s.add_development_dependency('rspec', '~>2.0')


### PR DESCRIPTION
So it turns out the rest_client is the same as rest-client but with
mime-type support removed. At first, my understanding was that they
had switched to underscore for some reason because rest_client was
of a newer version than rest-client. But actually the author of this
gem branched the feature set and only indicated this with an underscore.
